### PR TITLE
feat: Add database seed file with admin user

### DIFF
--- a/docs/plans/development-roadmap.md
+++ b/docs/plans/development-roadmap.md
@@ -35,7 +35,9 @@
   - Migration created: `init_better_auth_models`
   - Prisma generate re-enabled in `.github/workflows/ci.yml`
 
-- [ ] **Database seed file** (`packages/database/prisma/seed.ts`)
+- [x] **Database seed file** (`packages/database/prisma/seed.ts`) ✅ Completed
+  - Creates admin user (admin@example.com / admin123)
+  - Uses Better Auth crypto for password hashing
 
 ### Authentication
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@prisma/adapter-pg": "^7.0.0",
     "@prisma/client": "^7.0.0",
+    "better-auth": "^1.4.2",
     "dotenv": "^16.4.7",
     "pg": "^8.13.1"
   },

--- a/packages/database/prisma/seed.ts
+++ b/packages/database/prisma/seed.ts
@@ -1,0 +1,47 @@
+import { hashPassword } from 'better-auth/crypto';
+import 'dotenv/config';
+import { prisma } from '../src/index';
+
+async function main(): Promise<void> {
+  // Guard: only run in development
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('Seeding is not allowed in production');
+  }
+
+  console.log('Seeding database...');
+
+  // Clear existing data (cascade deletes sessions/accounts)
+  await prisma.verification.deleteMany();
+  await prisma.user.deleteMany();
+
+  // Hash password using Better Auth's utility
+  const hashedPassword = await hashPassword('admin123');
+
+  // Create admin user with credential account
+  const admin = await prisma.user.create({
+    data: {
+      name: 'Admin User',
+      email: 'admin@example.com',
+      emailVerified: true,
+      accounts: {
+        create: {
+          providerId: 'credential',
+          accountId: 'admin@example.com',
+          password: hashedPassword,
+        },
+      },
+    },
+    include: { accounts: true },
+  });
+
+  console.log('Created admin user:', admin.email);
+  console.log('Password: admin123');
+  console.log('Seeding complete!');
+}
+
+main()
+  .catch((e) => {
+    console.error('Seeding failed:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       '@prisma/client':
         specifier: ^7.0.0
         version: 7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      better-auth:
+        specifier: ^1.4.2
+        version: 1.4.9(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(mysql2@3.15.3)(pg@8.16.3)(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@2.1.9(@types/node@22.19.3))
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
@@ -4237,6 +4240,31 @@ snapshots:
     optionalDependencies:
       '@prisma/client': 7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
       '@tanstack/react-start': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@5.4.21(@types/node@22.19.3))
+      mysql2: 3.15.3
+      pg: 8.16.3
+      prisma: 7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      solid-js: 1.9.10
+      vitest: 2.1.9(@types/node@22.19.3)
+
+  better-auth@1.4.9(@prisma/client@7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)))(mysql2@3.15.3)(pg@8.16.3)(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(solid-js@1.9.10)(vitest@2.1.9(@types/node@22.19.3)):
+    dependencies:
+      '@better-auth/core': 1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.2.1))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.9(@better-auth/core@1.4.9(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.7(zod@4.2.1))(jose@6.1.3)(kysely@0.28.9)(nanostores@1.1.0))
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.1.7(zod@4.2.1)
+      defu: 6.1.4
+      jose: 6.1.3
+      kysely: 0.28.9
+      nanostores: 1.1.0
+      zod: 4.2.1
+    optionalDependencies:
+      '@prisma/client': 7.2.0(prisma@7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3))(typescript@5.9.3)
+      '@tanstack/react-start': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       mysql2: 3.15.3
       pg: 8.16.3
       prisma: 7.2.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- Add database seed file (`packages/database/prisma/seed.ts`) that creates an admin user for development testing
- Use Better Auth's crypto utilities for password hashing to ensure compatibility with auth setup
- Add `better-auth` dependency to the database package

## Test Credentials

| Email | Password |
|-------|----------|
| admin@example.com | admin123 |

## Usage

```bash
pnpm --filter database db:seed
```

## Test plan

- [x] Verify seed script runs successfully
- [x] Verify seed is idempotent (can run multiple times)
- [x] Verify user and account are created correctly in database
- [x] Verify type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)